### PR TITLE
fix: use globalThis instead of Window

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -48,7 +48,7 @@ export default async function getTotp(
   );
   new DataView(counterBuffer.buffer).setBigInt64(0, t);
 
-  const key = await window.crypto.subtle.importKey(
+  const key = await globalThis.crypto.subtle.importKey(
     "raw",
     base32ToUint8Array(token),
     { name: "HMAC", hash: "SHA-1" },


### PR DESCRIPTION
This adds Deno support.

I checked, and `globalThis.crypto` is available in at least the following environments:

- Node (v23)
- Bun (1.0.3)
- Firefox (132)
- Google Chrome (131)